### PR TITLE
Next key axis name

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -577,7 +577,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "fsspec"
-version = "2021.10.1"
+version = "2021.11.0"
 description = "File-system specification"
 category = "dev"
 optional = false
@@ -2485,7 +2485,7 @@ test = ["pytest"]
 
 [[package]]
 name = "treeo"
-version = "0.0.7"
+version = "0.0.8"
 description = ""
 category = "main"
 optional = false
@@ -2705,7 +2705,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "0c5168994daf0d1f565e54a51a1372dbe9d3273a6fab4ef3a126e2d32a9d5a1d"
+content-hash = "6487f7d2fdc0f5e785197f0f6e05dcac78975c8bac9553d30cd34c848fc7b6a0"
 
 [metadata.files]
 absl-py = [
@@ -3152,8 +3152,8 @@ frozenlist = [
     {file = "frozenlist-1.2.0.tar.gz", hash = "sha256:68201be60ac56aff972dc18085800b6ee07973c49103a8aba669dee3d71079de"},
 ]
 fsspec = [
-    {file = "fsspec-2021.10.1-py3-none-any.whl", hash = "sha256:7164a488f3f5bf6a0fb39674978b756dda84e011a5db411a79791b7c38a36ff7"},
-    {file = "fsspec-2021.10.1.tar.gz", hash = "sha256:c245626e3cb8de5cd91485840b215a385fa6f2b0f6ab87978305e99e2d842753"},
+    {file = "fsspec-2021.11.0-py3-none-any.whl", hash = "sha256:8843f31c7a7bb1afc4add371948f10701814594d407ee1b0bb4facec8b517efa"},
+    {file = "fsspec-2021.11.0.tar.gz", hash = "sha256:cbb7bafd59aa33684a92e843877f4adc0109fb0722b1a26e7d08f5a6e2500904"},
 ]
 gast = [
     {file = "gast-0.4.0-py3-none-any.whl", hash = "sha256:b7adcdd5adbebf1adf17378da5ba3f543684dbec47b1cda1f3997e573cd542c4"},
@@ -4343,8 +4343,8 @@ traitlets = [
     {file = "traitlets-5.1.1.tar.gz", hash = "sha256:059f456c5a7c1c82b98c2e8c799f39c9b8128f6d0d46941ee118daace9eb70c7"},
 ]
 treeo = [
-    {file = "treeo-0.0.7-py3-none-any.whl", hash = "sha256:0ac9bbeefc9909cc797fb1b58a5ae43ed058795d94f0571c8f48e66e47a942f8"},
-    {file = "treeo-0.0.7.tar.gz", hash = "sha256:5aae3fded95244cbc6b186dfd743e5d27843014f50701196dc1419544af0d32b"},
+    {file = "treeo-0.0.8-py3-none-any.whl", hash = "sha256:ccef15103d7214441c43bde2b4af50d6d75ce6237d582afe9b9a8cf3114e04bb"},
+    {file = "treeo-0.0.8.tar.gz", hash = "sha256:d9f334cb78c82e28f9424f796361c401b8dbee7a9055ba5ba041bbf6ee8ab22b"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ PyYAML = "^5.4.1"
 rich = "^10.7.0"
 optax = "^0.0.9"
 einops = "^0.3.2"
-treeo = "^0.0.7"
+treeo = "^0.0.8"
 # treeo = { path = "../treeo", develop = true }
 
 [tool.poetry.dev-dependencies]

--- a/tests/nn/test_linear.py
+++ b/tests/nn/test_linear.py
@@ -1,7 +1,12 @@
+import functools
+import typing as tp
 import unittest
+from dataclasses import dataclass
 
+import einops
 import hypothesis as hp
 import jax
+import jax.numpy as jnp
 import numpy as np
 from flax import linen
 from hypothesis import strategies as st
@@ -22,6 +27,8 @@ KERNEL_INITS = BIAS_INITS + (
     tx.initializers.kaiming_uniform(),
     tx.initializers.kaiming_normal(),
 )
+
+A = tp.TypeVar("A")
 
 
 class LinearTest(unittest.TestCase):
@@ -128,3 +135,69 @@ class LinearTest(unittest.TestCase):
             np.allclose(a, b)
             for a, b in zip(jax.tree_leaves(module), jax.tree_leaves(module2))
         )
+
+    def test_axis_name(self):
+        class Linear3D(tx.Linear):
+            def __init__(
+                self,
+                num_heads: int,
+                *args,
+                axis_name: tp.Any = "batch",
+                **kwargs,
+            ):
+                super().__init__(*args, axis_name=axis_name, **kwargs)
+                self.num_heads = num_heads
+
+            def __call__(self, x):
+                def call(module: "Linear3D", x):
+                    x = super(module.__class__, module).__call__(x)
+                    return x, module
+
+                x = einops.repeat(x, "... -> head ...", head=self.num_heads)
+                x, module = jax.vmap(call, axis_name=self.axis_name)(self, x)
+
+                self.merge(module, inplace=True)
+
+                return x
+
+        num_heads = 4
+        units = 3
+
+        x = np.random.uniform(size=(5, 2))
+
+        module = Linear3D(num_heads, units).init(42, x)
+
+        y = module(x)
+
+        assert y.shape == (num_heads, 5, units)
+
+    def test_vmap_compact(self):
+        @dataclass
+        class Linear3D(tx.Module):
+            num_heads: int
+            units: int
+
+            @tx.preserve_state(jax.vmap, axis_name="head")
+            @tx.compact
+            def _forward(self, x: jnp.ndarray) -> jnp.ndarray:
+                x = tx.Linear(self.units, axis_name="head")(x)
+                return x
+
+            def __call__(self, x):
+                x = einops.repeat(x, "... -> head ...", head=self.num_heads)
+                x = self._forward(x)
+                return x
+
+        num_heads = 4
+        units = 3
+
+        x = np.random.uniform(size=(5, 2))
+
+        module = Linear3D(num_heads, units).init(42, x)
+
+        assert module.linear.kernel.shape == (num_heads, 2, units)
+        assert module.linear.bias.shape == (num_heads, units)
+
+        y = module(x)
+
+        assert y.shape == (num_heads, 5, 3)

--- a/treex/module.py
+++ b/treex/module.py
@@ -18,10 +18,6 @@ from treex.treex import Filters, Treex
 A = tp.TypeVar("A")
 B = tp.TypeVar("B")
 M = tp.TypeVar("M", bound="Module")
-Filter = tp.Union[
-    tp.Type[tp.Type[tp.Any]],
-    tp.Callable[[to.FieldInfo], bool],
-]
 
 
 @dataclass

--- a/treex/module.py
+++ b/treex/module.py
@@ -17,6 +17,7 @@ from treex.treex import Filters, Treex
 
 A = tp.TypeVar("A")
 B = tp.TypeVar("B")
+C = tp.TypeVar("C", bound=tp.Callable[..., tp.Any])
 M = tp.TypeVar("M", bound="Module")
 
 
@@ -361,19 +362,105 @@ def compact_module(f) -> type:
     return module_class
 
 
-def next_key() -> jnp.ndarray:
+def preserve_state(
+    transformation: C, *transformation_args, **transformation_kwargs
+) -> C:
+    """
+    Takes in a function transformation such as `jit` or `vmap` and the function `f`
+    to be transformed and returns a the transformed function with the expected behaviour
+    but that additionally preserves the state of the first argument of `f`.
+
+    For example, within a `Module`  if you try to `vmap` over a method with stateful operations like this:
+
+    ```python
+    @jax.vmap
+    def __call__(self, x):
+        self.n += 1
+        return 2.0 * x
+    ```
+
+    It will not work since the composed function `vmap(__call__)` is a pure function so any change
+    to `self` will not be reflected outside.
+
+
+    To solve you can wrap `vmap` using `preserve_state` like this:
+
+    ```python
+    @preserve_state(jax.vmap)
+    def __call__(self, x):
+        self.n += 1
+        return 2.0 * x
+    ```
+
+    This will guarantee that the state of `self` is propagated to the outside.
+
+    Arguments:
+        transformation: The transformation to be applied to the function `f`.
+        f: The function to be transformed.
+        *args: Additional arguments to be passed to the transformation.
+        **kwargs: Additional keyword arguments to be passed to the transformation.
+
+    Returns:
+        The transformed function.
+    """
+
+    @functools.wraps(transformation)
+    def new_transformation(f):
+        f_original = f
+
+        f = _return_first(f)
+        f = _update_first(
+            transformation(f, *transformation_args, **transformation_kwargs)
+        )
+
+        @functools.wraps(f_original)
+        def wrapper(*args, **kwargs):
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    return new_transformation
+
+
+def _return_first(f):
+    def wrapper(self, *args, **kwargs):
+        y = f(self, *args, **kwargs)
+        return self, y
+
+    return wrapper
+
+
+def _update_first(f):
+    def wrapper(self, *args, **kwargs):
+        module, y = f(self, *args, **kwargs)
+
+        self.__dict__.update(module.__dict__)
+
+        return y
+
+    return wrapper
+
+
+def next_key(*, axis_name: tp.Optional[tp.Any] = None) -> jnp.ndarray:
     """
     Returns the next key.
 
     Returns:
         The next key.
     """
+    key: jnp.ndarray
+
     if _INIT_CONTEXT.key is None:
         raise RuntimeError(
             "RNG key not set, you are either calling an uninitialized Module outside `.init` or forgot to call `rng_key` context manager."
         )
 
     key, _INIT_CONTEXT.key = utils.iter_split(_INIT_CONTEXT.key)
+
+    if axis_name is not None:
+        axis_index = jax.lax.axis_index(axis_name)
+        key = jax.random.fold_in(key, axis_index)
+
     return key
 
 

--- a/treex/nn/linear.py
+++ b/treex/nn/linear.py
@@ -54,6 +54,7 @@ class Linear(Module):
             flax_module.Array,
         ] = flax_module.zeros,
         name: tp.Optional[str] = None,
+        axis_name: tp.Optional[tp.Any] = None
     ):
         """
         Arguments:
@@ -73,6 +74,7 @@ class Linear(Module):
         self.precision = precision
         self.kernel_init = kernel_init
         self.bias_init = bias_init
+        self.axis_name = axis_name
 
         self.kernel = None
         self.bias = None
@@ -98,7 +100,8 @@ class Linear(Module):
             The transformed input.
         """
         if self.initializing():
-            variables = self.module.init({"params": next_key()}, x)
+            rngs = {"params": next_key(axis_name=self.axis_name)}
+            variables = self.module.init(rngs, x)
 
             # Extract collections
             params = variables["params"].unfreeze()

--- a/treex/treex.py
+++ b/treex/treex.py
@@ -6,10 +6,6 @@ from treex import types
 
 A = tp.TypeVar("A")
 T = tp.TypeVar("T", bound="Treex")
-Filter = tp.Union[
-    tp.Type[tp.Type[tp.Any]],
-    tp.Callable[[to.FieldInfo], bool],
-]
 
 
 class Treex(to.Tree, to.Extensions):
@@ -76,7 +72,7 @@ class Treex(to.Tree, to.Extensions):
 
 
 class Filters:
-    def parameters(self: A, *filters: Filter) -> A:
+    def parameters(self: A, *filters: types.Filter) -> A:
         """
         Returns a copy of the Module with only tx.Parameter TreeParts, alias for `filter(tx.Parameter)`.
 
@@ -85,7 +81,7 @@ class Filters:
         """
         return to.filter(self, types.Parameter, *filters)
 
-    def batch_stats(self: A, *filters: Filter) -> A:
+    def batch_stats(self: A, *filters: types.Filter) -> A:
         """
         Returns a copy of the Module with only tx.BatchStat TreeParts, alias for `filter(tx.BatchStat)`.
 
@@ -94,7 +90,7 @@ class Filters:
         """
         return to.filter(self, types.BatchStat, *filters)
 
-    def rngs(self: A, *filters: Filter) -> A:
+    def rngs(self: A, *filters: types.Filter) -> A:
         """
         Returns a copy of the Module with only tx.Rng TreeParts, alias for `filter(tx.Rng)`.
 
@@ -103,7 +99,7 @@ class Filters:
         """
         return to.filter(self, types.Rng, *filters)
 
-    def model_states(self: A, *filters: Filter) -> A:
+    def model_states(self: A, *filters: types.Filter) -> A:
         """
         Returns a copy of the Module with only tx.ModelState TreeParts, alias for `filter(tx.ModelState)`.
 
@@ -112,7 +108,7 @@ class Filters:
         """
         return to.filter(self, types.ModelState, *filters)
 
-    def states(self: A, *filters: Filter) -> A:
+    def states(self: A, *filters: types.Filter) -> A:
         """
         Returns a copy of the Module with only tx.State TreeParts, alias for `filter(tx.State)`.
 
@@ -121,7 +117,7 @@ class Filters:
         """
         return to.filter(self, types.State, *filters)
 
-    def metric_logs(self: A, *filters: Filter) -> A:
+    def metric_logs(self: A, *filters: types.Filter) -> A:
         """
         Returns a copy of the Module with only tx.Metric TreeParts, alias for `filter(tx.Metric)`.
 
@@ -130,7 +126,7 @@ class Filters:
         """
         return to.filter(self, types.MetricLog, *filters)
 
-    def loss_logs(self: A, *filters: Filter) -> A:
+    def loss_logs(self: A, *filters: types.Filter) -> A:
         """
         Returns a copy of the Module with only tx.Loss TreeParts, alias for `filter(tx.Loss)`.
 
@@ -139,7 +135,7 @@ class Filters:
         """
         return to.filter(self, types.LossLog, *filters)
 
-    def logs(self: A, *filters: Filter) -> A:
+    def logs(self: A, *filters: types.Filter) -> A:
         """
         Returns a copy of the Module with only tx.Log TreeParts, alias for `filter(tx.Log)`.
 
@@ -148,7 +144,7 @@ class Filters:
         """
         return to.filter(self, types.Log, *filters)
 
-    def caches(self: A, *filters: Filter) -> A:
+    def caches(self: A, *filters: types.Filter) -> A:
         """
         Returns a copy of the Module with only tx.Cache TreeParts, alias for `filter(tx.Cache)`.
 

--- a/treex/types.py
+++ b/treex/types.py
@@ -10,6 +10,10 @@ import typing_extensions as tpe
 
 A = tp.TypeVar("A")
 B = tp.TypeVar("B")
+Filter = tp.Union[
+    tp.Type[tp.Type[tp.Any]],
+    tp.Callable[[to.FieldInfo], bool],
+]
 
 InputLike = tp.Union[tp.Any, tp.Tuple[tp.Any, ...], tp.Dict[str, tp.Any], "Inputs"]
 IndexLike = tp.Union[str, int, tp.Sequence[tp.Union[str, int]]]


### PR DESCRIPTION
# Changes
* Adds a `axis_name` argument to `next_key`, `KeySeq`, and `Linear`.
* Creates the `preserve_state` function that enables you apply a function transformation like `jit` or `vmap` to a stateful method that doesn't propagate the state by returning `self`; `preserver_state` will return the first argument and update it after the transformation.
* Fixes type issues with `Filter` in shortcut methods.