### PR TITLE
Remove duplicate import of Haiku Module

### DIFF
--- a/treex/nn/__init__.py
+++ b/treex/nn/__init__.py
@@ -5,7 +5,6 @@ from .conv import Conv
 from .dropout import Dropout
 from .flatten import Flatten
 from .flax_module import FlaxModule
-from .haiku_module import HaikuModule
 from .linear import Linear
 from .mlp import MLP
 from .sequential import Lambda, Sequential, sequence


### PR DESCRIPTION
I believe the import of haiku is meant to be the second one within the
`try` block as it is an optional dependency.

PS: Sorry for yet another 1-line PR