### PR TITLE
Add `trainable_parameters` for extracting non-frozen parameters

### DIFF
--- a/docs/user-guide/freezing-modules.md
+++ b/docs/user-guide/freezing-modules.md
@@ -24,7 +24,7 @@ for layer in model.layers[:-1]:
 # fine-tune the model
 ...
 ```
-In this example we can leveraged the fact that `Sequential` has its submodules in `.layers` to freeze all but the last layers. 
+In this example we can leveraged the fact that `Sequential` has its submodules in `.layers` to freeze all but the last layers.
 
 Freezing modules is useful for tasks such as Transfer Learning where you want to keep most of the weights in a model unchange and train only a few of them on a new dataset. If you have a backbone you can just freeze the entire model.
 
@@ -38,17 +38,15 @@ model = tx.Sequential(
 ).init(42)
 
 ...
+# Initialize optimizer with only the trainable set of parameters
+optimizer = optimizer.init(model.trainable_parameters())
+...
 
 @jax.jit
 def train_step(model, x, y, optimizer):
     # only differentiate w.r.t. parameters whose module is not frozen
-    params = model.filter(
-        tx.Parameter,
-        lambda field: not field.module.frozen,
-    )
+    params = model.trainable_parameters()
     (loss, model), grads = loss_fn(params, model, x, y)
 
     ...
 ```
-
-Notice that here we used a custom callback to `filter` to select only parameters from Modules that are not frozen.

--- a/tests/test_treex.py
+++ b/tests/test_treex.py
@@ -610,7 +610,6 @@ class TestTreex:
         print(module.tabulate())
 
     def test_treex_filter(self):
-
         tree = dict(a=1, b=Linear(3, 4))
 
         tree2 = tx.filter(tree, tx.Parameter)
@@ -618,6 +617,16 @@ class TestTreex:
 
         tree2 = tx.filter(tree, lambda field: isinstance(field.value, int))
         assert tree2["a"] == 1
+
+    def test_treex_parameter_filter(self):
+        mlp = MLP(2, 3, 5)
+        mlp.linear1.freeze(inplace=True)
+
+        params = mlp.trainable_parameters()
+        assert isinstance(params.linear1.b, tx.Nothing)
+        assert isinstance(params.linear1.w, tx.Nothing)
+        assert not isinstance(params.linear2.b, tx.Nothing)
+        assert not isinstance(params.linear2.w, tx.Nothing)
 
     def test_module_map(self):
         class A(tx.Module):

--- a/treex/treex.py
+++ b/treex/treex.py
@@ -81,6 +81,16 @@ class Filters:
         """
         return to.filter(self, types.Parameter, *filters)
 
+    def trainable_parameters(self: A, *filters: types.Filter) -> A:
+        """
+        Returns a copy of the Module with only tx.Parameter TreeParts which are not frozen, alias for
+        `filter(tx.Parameter, lambda field: not field.module.frozen)`.
+
+        Arguments:
+            filters: additional filters passed to `filter`.
+        """
+        return self.parameters(lambda field: not field.module.frozen, *filters)
+
     def batch_stats(self: A, *filters: types.Filter) -> A:
         """
         Returns a copy of the Module with only tx.BatchStat TreeParts, alias for `filter(tx.BatchStat)`.


### PR DESCRIPTION
This adds a `trainable_parameters` filter which filters out parts of a
given `tx.Module` which have been frozen. Also modified the docs to
reflect this change and how it can be used when training a model with
frozen sections.