### PR TITLE
Fix metric argument names

### DIFF
--- a/tests/metrics/test_mean_absolute_error.py
+++ b/tests/metrics/test_mean_absolute_error.py
@@ -11,14 +11,14 @@ import treex as tx
 class TestMAE:
     def test_mae_basic(self):
 
-        y_true = np.random.randn(8, 20, 20)
-        y_pred = np.random.randn(8, 20, 20)
+        target = np.random.randn(8, 20, 20)
+        preds = np.random.randn(8, 20, 20)
 
         mae_tx = tx.metrics.MeanAbsoluteError()
-        mae_tx_value = mae_tx(y_true=y_true, y_pred=y_pred)
+        mae_tx_value = mae_tx(target=target, preds=preds)
 
         mae_tm = tm.MeanAbsoluteError()
-        mae_tm_value = mae_tm(torch.from_numpy(y_pred), torch.from_numpy(y_true))
+        mae_tm_value = mae_tm(torch.from_numpy(preds), torch.from_numpy(target))
         assert np.isclose(np.array(mae_tx_value), mae_tm_value.numpy())
 
     @hp.given(
@@ -27,8 +27,8 @@ class TestMAE:
     @hp.settings(deadline=None, max_examples=10)
     def test_mae_weights_batch_dim(self, use_sample_weight):
 
-        y_true = np.random.randn(8, 20, 20)
-        y_pred = np.random.randn(8, 20, 20)
+        target = np.random.randn(8, 20, 20)
+        preds = np.random.randn(8, 20, 20)
 
         if use_sample_weight:
             sum = 0
@@ -36,7 +36,7 @@ class TestMAE:
                 sample_weight = np.random.choice([0, 1], 8)
                 sum = sample_weight.sum()
 
-        params = {"y_true": y_true, "y_pred": y_pred}
+        params = {"target": target, "preds": preds}
         mae_tx = tx.metrics.MeanAbsoluteError()
         if use_sample_weight:
             params.update({"sample_weight": sample_weight})
@@ -44,8 +44,8 @@ class TestMAE:
 
         mae_tx = tx.metrics.MeanAbsoluteError()
         if use_sample_weight:
-            y_true, y_pred = y_true[sample_weight == 1], y_pred[sample_weight == 1]
-        mae_tx_no_sample_weight = mae_tx(y_true=y_true, y_pred=y_pred)
+            target, preds = target[sample_weight == 1], preds[sample_weight == 1]
+        mae_tx_no_sample_weight = mae_tx(target=target, preds=preds)
 
         assert np.isclose(mae_tx_value, mae_tx_no_sample_weight)
 
@@ -55,10 +55,10 @@ class TestMAE:
     @hp.settings(deadline=None, max_examples=10)
     def test_mae_weights_values_dim(self, use_sample_weight):
 
-        y_true = np.random.randn(8, 20, 20)
-        y_pred = np.random.randn(8, 20, 20)
+        target = np.random.randn(8, 20, 20)
+        preds = np.random.randn(8, 20, 20)
 
-        params = {"y_true": y_true, "y_pred": y_pred}
+        params = {"target": target, "preds": preds}
         if use_sample_weight:
             sample_weight = np.random.choice([0, 1], 8 * 20).reshape((8, 20))
             params.update({"sample_weight": sample_weight})
@@ -72,11 +72,11 @@ class TestMAE:
         mae_tm = tm.MeanAbsoluteError()
         for batch in range(2):
 
-            y_true = np.random.randn(8, 5, 5)
-            y_pred = np.random.randn(8, 5, 5)
+            target = np.random.randn(8, 5, 5)
+            preds = np.random.randn(8, 5, 5)
 
-            mae_tx(y_true=y_true, y_pred=y_pred)
-            mae_tm(torch.from_numpy(y_pred), torch.from_numpy(y_true))
+            mae_tx(target=target, preds=preds)
+            mae_tm(torch.from_numpy(preds), torch.from_numpy(target))
 
         assert np.isclose(
             np.array(mae_tx.compute()),
@@ -85,9 +85,9 @@ class TestMAE:
 
     def test_mae_short(self):
 
-        y_true = np.random.randn(8, 20, 20)
-        y_pred = np.random.randn(8, 20, 20)
+        target = np.random.randn(8, 20, 20)
+        preds = np.random.randn(8, 20, 20)
 
-        mae_tx_long = tx.metrics.MeanAbsoluteError()(y_true=y_true, y_pred=y_pred)
-        mae_tx_short = tx.metrics.MAE()(y_true=y_true, y_pred=y_pred)
+        mae_tx_long = tx.metrics.MeanAbsoluteError()(target=target, preds=preds)
+        mae_tx_short = tx.metrics.MAE()(target=target, preds=preds)
         assert np.isclose(np.array(mae_tx_long), np.array(mae_tx_short))

--- a/tests/metrics/test_mean_square_error.py
+++ b/tests/metrics/test_mean_square_error.py
@@ -11,14 +11,14 @@ import treex as tx
 class TestMSE:
     def test_mse_basic(self):
 
-        y_true = np.random.randn(8, 20, 20)
-        y_pred = np.random.randn(8, 20, 20)
+        target = np.random.randn(8, 20, 20)
+        preds = np.random.randn(8, 20, 20)
 
         mse_tx = tx.metrics.MeanSquareError()
-        mse_tx_value = mse_tx(y_true=y_true, y_pred=y_pred)
+        mse_tx_value = mse_tx(target=target, preds=preds)
 
         mse_tm = tm.MeanSquaredError()
-        mse_tm_value = mse_tm(torch.from_numpy(y_pred), torch.from_numpy(y_true))
+        mse_tm_value = mse_tm(torch.from_numpy(preds), torch.from_numpy(target))
         assert np.isclose(np.array(mse_tx_value), mse_tm_value.numpy())
 
     def test_accumulative_mse(self):
@@ -26,11 +26,11 @@ class TestMSE:
         mse_tm = tm.MeanSquaredError()
 
         for batch in range(2):
-            y_true = np.random.randn(8, 5, 5)
-            y_pred = np.random.randn(8, 5, 5)
+            target = np.random.randn(8, 5, 5)
+            preds = np.random.randn(8, 5, 5)
 
-            mse_tx(y_true=y_true, y_pred=y_pred)
-            mse_tm(torch.from_numpy(y_pred), torch.from_numpy(y_true))
+            mse_tx(target=target, preds=preds)
+            mse_tm(torch.from_numpy(preds), torch.from_numpy(target))
 
         assert np.isclose(
             np.array(mse_tx.compute()),
@@ -39,11 +39,11 @@ class TestMSE:
 
     def test_mse_short(self):
 
-        y_true = np.random.randn(8, 20, 20)
-        y_pred = np.random.randn(8, 20, 20)
+        target = np.random.randn(8, 20, 20)
+        preds = np.random.randn(8, 20, 20)
 
-        mse_tx_long = tx.metrics.MeanSquareError()(y_true=y_true, y_pred=y_pred)
-        mse_tx_short = tx.metrics.MSE()(y_true=y_true, y_pred=y_pred)
+        mse_tx_long = tx.metrics.MeanSquareError()(target=target, preds=preds)
+        mse_tx_short = tx.metrics.MSE()(target=target, preds=preds)
         assert np.isclose(np.array(mse_tx_long), np.array(mse_tx_short))
 
     @hp.given(
@@ -52,10 +52,10 @@ class TestMSE:
     @hp.settings(deadline=None, max_examples=10)
     def test_mse_weights(self, use_sample_weight):
 
-        y_true = np.random.randn(8, 20, 20)
-        y_pred = np.random.randn(8, 20, 20)
+        target = np.random.randn(8, 20, 20)
+        preds = np.random.randn(8, 20, 20)
 
-        params = {"y_true": y_true, "y_pred": y_pred}
+        params = {"target": target, "preds": preds}
         mse_tx = tx.metrics.MeanSquareError()
 
         if use_sample_weight:
@@ -67,7 +67,7 @@ class TestMSE:
         mse_tx_value = mse_tx(**params)
 
         if use_sample_weight:
-            y_true, y_pred = y_true[sample_weight == 1], y_pred[sample_weight == 1]
+            target, preds = target[sample_weight == 1], preds[sample_weight == 1]
 
         mse_tx = tx.metrics.MeanSquareError()
         mse_tx_no_sample_weight = mse_tx(**params)
@@ -80,10 +80,10 @@ class TestMSE:
     @hp.settings(deadline=None, max_examples=10)
     def test_mse_weights_values_dim(self, use_sample_weight):
 
-        y_true = np.random.randn(8, 20, 20)
-        y_pred = np.random.randn(8, 20, 20)
+        target = np.random.randn(8, 20, 20)
+        preds = np.random.randn(8, 20, 20)
 
-        params = {"y_true": y_true, "y_pred": y_pred}
+        params = {"target": target, "preds": preds}
         if use_sample_weight:
             sample_weight = np.random.choice([0, 1], 8 * 20).reshape((8, 20))
             params.update({"sample_weight": sample_weight})

--- a/treex/metrics/mean_absolute_error.py
+++ b/treex/metrics/mean_absolute_error.py
@@ -6,19 +6,19 @@ from treex import types
 from treex.metrics.mean import Mean
 
 
-def _mean_absolute_error(y_pred: jnp.ndarray, y_true: jnp.ndarray) -> jnp.ndarray:
-    """Calculates values required to update/compute Mean Absolute Error. Cast y_pred to have the same type as y_true.
+def _mean_absolute_error(preds: jnp.ndarray, target: jnp.ndarray) -> jnp.ndarray:
+    """Calculates values required to update/compute Mean Absolute Error. Cast preds to have the same type as target.
 
     Args:
-        y_pred: Predicted tensor
-        y_true: Ground truth tensor
+        preds: Predicted tensor
+        target: Ground truth tensor
 
     Returns:
         jnp.ndarray values needed to update Mean Absolute Error
     """
 
-    y_true = y_true.astype(y_pred.dtype)
-    return jnp.abs(y_pred - y_true)
+    target = target.astype(preds.dtype)
+    return jnp.abs(preds - target)
 
 
 class MeanAbsoluteError(Mean):
@@ -36,11 +36,11 @@ class MeanAbsoluteError(Mean):
         Args:
             on:
                 A string or integer, or iterable of string or integers, that
-                indicate how to index/filter the `y_true` and `y_pred`
+                indicate how to index/filter the `target` and `preds`
                 arguments before passing them to `call`. For example if `on = "a"` then
-                `y_true = y_true["a"]`. If `on` is an iterable
+                `target = target["a"]`. If `on` is an iterable
                 the structures will be indexed iteratively, for example if `on = ["a", 0, "b"]`
-                then `y_true = y_true["a"][0]["b"]`, same for `y_pred`. For more information
+                then `target = target["a"][0]["b"]`, same for `preds`. For more information
                 check out [Keras-like behavior](https://poets-ai.github.io/elegy/guides/modules-losses-metrics/#keras-like-behavior).
             name:
                 Module name
@@ -52,33 +52,33 @@ class MeanAbsoluteError(Mean):
         >>> import jax.numpy as jnp
         >>> from treex.metrics.mean_absolute_error import MeanAbsolutError
 
-        >>> y_true = jnp.array([3.0, -0.5, 2.0, 7.0])
-        >>> y_pred = jnp.array([3.0, -0.5, 2.0, 7.0])
+        >>> target = jnp.array([3.0, -0.5, 2.0, 7.0])
+        >>> preds = jnp.array([3.0, -0.5, 2.0, 7.0])
 
         >>> mae = MeanAbsolutError()
-        >>> mae(y_pred, y_true)
+        >>> mae(preds, target)
 
         """
         super().__init__(on=on, name=name, dtype=dtype)
 
     def update(
         self,
-        y_true: jnp.ndarray,
-        y_pred: jnp.ndarray,
+        target: jnp.ndarray,
+        preds: jnp.ndarray,
         sample_weight: jnp.ndarray = None,
     ) -> tp.Any:
         """
-        Accumulates metric statistics. `y_true` and `y_pred` should have the same shape.
+        Accumulates metric statistics. `target` and `preds` should have the same shape.
 
         Arguments:
-            y_true:
+            target:
                 Ground truth values. shape = `[batch_size, d0, .. dN]`.
-            y_pred:
+            preds:
                 The predicted values. shape = `[batch_size, d0, .. dN]`
             sample_weight:
                 Optional weighting of each example. Defaults to 1. shape = `[batch_size, d0, .. dN]`
         Returns:
             Array with the cumulative mean absolute error.
         """
-        values = _mean_absolute_error(y_pred, y_true)
+        values = _mean_absolute_error(preds, target)
         return super().update(values, sample_weight)

--- a/treex/metrics/mean_square_error.py
+++ b/treex/metrics/mean_square_error.py
@@ -6,19 +6,19 @@ from treex import types
 from treex.metrics.mean import Mean
 
 
-def _mean_square_error(y_pred: jnp.ndarray, y_true: jnp.ndarray) -> jnp.ndarray:
-    """Calculates values required to update/compute Mean Square Error. Cast y_pred to have the same type as y_true.
+def _mean_square_error(preds: jnp.ndarray, target: jnp.ndarray) -> jnp.ndarray:
+    """Calculates values required to update/compute Mean Square Error. Cast preds to have the same type as target.
 
     Args:
-        y_pred: Predicted tensor
-        y_true: Ground truth tensor
+        preds: Predicted tensor
+        target: Ground truth tensor
 
     Returns:
         jnp.ndarray values needed to update Mean Square Error
     """
 
-    y_true = y_true.astype(y_pred.dtype)
-    return jnp.square(y_pred - y_true)
+    target = target.astype(preds.dtype)
+    return jnp.square(preds - target)
 
 
 class MeanSquareError(Mean):
@@ -36,11 +36,11 @@ class MeanSquareError(Mean):
         Args:
             on:
                 A string or integer, or iterable of string or integers, that
-                indicate how to index/filter the `y_true` and `y_pred`
+                indicate how to index/filter the `target` and `preds`
                 arguments before passing them to `call`. For example if `on = "a"` then
-                `y_true = y_true["a"]`. If `on` is an iterable
+                `target = target["a"]`. If `on` is an iterable
                 the structures will be indexed iteratively, for example if `on = ["a", 0, "b"]`
-                then `y_true = y_true["a"][0]["b"]`, same for `y_pred`. For more information
+                then `target = target["a"][0]["b"]`, same for `preds`. For more information
                 check out [Keras-like behavior](https://poets-ai.github.io/elegy/guides/modules-losses-metrics/#keras-like-behavior).
             name:
                 Module name
@@ -52,33 +52,33 @@ class MeanSquareError(Mean):
         >>> import jax.numpy as jnp
         >>> from treex.metrics.mean_square_error import MeanSquareError
 
-        >>> y_true = jnp.array([3.0, -0.5, 2.0, 7.0])
-        >>> y_pred = jnp.array([3.0, -0.5, 2.0, 7.0])
+        >>> target = jnp.array([3.0, -0.5, 2.0, 7.0])
+        >>> preds = jnp.array([3.0, -0.5, 2.0, 7.0])
 
         >>> mse = MeanSquareError()
-        >>> mse(y_pred, y_true)
+        >>> mse(preds, target)
 
         """
         super().__init__(on=on, name=name, dtype=dtype)
 
     def update(
         self,
-        y_true: jnp.ndarray,
-        y_pred: jnp.ndarray,
+        target: jnp.ndarray,
+        preds: jnp.ndarray,
         sample_weight: jnp.ndarray = None,
     ) -> tp.Any:
         """
-        Accumulates metric statistics. `y_true` and `y_pred` should have the same shape.
+        Accumulates metric statistics. `target` and `preds` should have the same shape.
 
         Arguments:
-            y_true:
+            target:
                 Ground truth values. shape = `[batch_size, d0, .. dN]`.
-            y_pred:
+            preds:
                 The predicted values. shape = `[batch_size, d0, .. dN]`
             sample_weight:
                 Optional weighting of each example. Defaults to 1. shape = `[batch_size, d0, .. dN]`
         Returns:
             Array with the cumulative mean absolute error.
         """
-        values = _mean_square_error(y_pred, y_true)
+        values = _mean_square_error(preds, target)
         return super().update(values, sample_weight)


### PR DESCRIPTION
# Changes
* Replaces `y_true -> target` and `y_pred -> preds` arguments for `MeanSquaredError` and `MeanAbsoluteError`.
* Fixes #55 and poets-ai/elegy#216