### PR TITLE
Support python 3.7.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2416,8 +2416,8 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.7.1,<3.11"
-content-hash = "f14bb8b8e47f5f448cab761ebc5a4514c5e3814a3c61e1540a204379b5da5bdf"
+python-versions = ">=3.7,<3.11"
+content-hash = "add11f2eb8dc0bf38c2a1c61e0cb3ff32e8737e3aef0e0dd41351fc6b7ea0568"
 
 [metadata.files]
 absl-py = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ url = "https://eternalphane.github.io/pytorch-pypi/"
 secondary = true
 
 [tool.poetry.dependencies]
-python = ">=3.7.1,<3.11"
+python = ">=3.7,<3.11"
 flax = "^0.4.0"
 PyYAML = "^6.0"
 rich = "^11.2.0"
@@ -44,7 +44,7 @@ pytest-cov = "^3.0.0"
 tensorflow-cpu = "^2.8.0"
 datasets = "^1.18.3"
 typer = "^0.4.0"
-mkdocs-jupyter = "^0.20.0"
+mkdocs-jupyter = {version="^0.20.0", python=">=3.7.1"}
 
 
 [build-system]


### PR DESCRIPTION
# Changes
Recent change briefly added a restraint on poetry for `python>=3.7.1` so `mkdocs-jupyter` could be installed. Since this is a dev dependecy its easier just to add the restraint on `mkdocs-jupyter` itself.