### PR TITLE
[WIP] Add Attention module

### DIFF
--- a/tests/nn/test_attention.py
+++ b/tests/nn/test_attention.py
@@ -1,0 +1,219 @@
+import unittest
+
+import hypothesis as hp
+import jax
+import numpy as np
+from flax import linen
+from hypothesis import strategies as st
+
+import treex as tx
+
+BIAS_INITS = (
+    tx.initializers.zeros,
+    tx.initializers.ones,
+    tx.initializers.normal(),
+    tx.initializers.uniform(),
+)
+KERNEL_INITS = BIAS_INITS + (
+    tx.initializers.xavier_uniform(),
+    tx.initializers.xavier_normal(),
+    tx.initializers.lecun_uniform(),
+    tx.initializers.lecun_normal(),
+    tx.initializers.kaiming_uniform(),
+    tx.initializers.kaiming_normal(),
+)
+
+
+class MultiHeadDotProductAttentionTest(unittest.TestCase):
+    @hp.given(
+        batch_size=st.integers(min_value=1, max_value=32),
+        length=st.integers(min_value=1, max_value=32),
+        log2_features_in=st.integers(min_value=1, max_value=5),
+        log2_num_heads=st.integers(min_value=1, max_value=3),
+        log2_qkv_features=st.integers(min_value=1, max_value=5),
+        log2_out_features=st.integers(min_value=1, max_value=5),
+        broadcast_dropout=st.booleans(),
+        dropout_rate=st.floats(min_value=0.0, max_value=1.0),
+        deterministic=st.booleans(),
+        kernel_init=st.sampled_from(KERNEL_INITS),
+        bias_init=st.sampled_from(BIAS_INITS),
+        use_bias=st.booleans(),
+        decode=st.booleans(),
+        training=st.booleans(),
+    )
+    @hp.settings(deadline=None, max_examples=1)
+    def test_equivalence(
+        self,
+        batch_size,
+        length,
+        log2_features_in,
+        log2_num_heads,
+        log2_qkv_features,
+        log2_out_features,
+        broadcast_dropout,
+        dropout_rate,
+        deterministic,
+        kernel_init,
+        bias_init,
+        use_bias,
+        decode,
+        training,
+    ):
+
+        shape = (batch_size, length, 2 ** log2_features_in)
+
+        inputs_q = np.random.uniform(size=shape)
+        inputs_kv = np.random.uniform(size=shape)
+
+        key = tx.Key(42)
+
+        flax_module = linen.MultiHeadDotProductAttention(
+            num_heads=2 ** log2_num_heads,
+            qkv_features=2 ** log2_qkv_features,
+            out_features=2 ** log2_out_features,
+            broadcast_dropout=broadcast_dropout,
+            dropout_rate=dropout_rate,
+            deterministic=deterministic,
+            kernel_init=kernel_init,
+            bias_init=bias_init,
+            use_bias=use_bias,
+            decode=False,
+        )
+        treex_module = tx.MultiHeadDotProductAttention(
+            num_heads=2 ** log2_num_heads,
+            qkv_features=2 ** log2_qkv_features,
+            out_features=2 ** log2_out_features,
+            broadcast_dropout=broadcast_dropout,
+            dropout_rate=dropout_rate,
+            deterministic=deterministic,
+            kernel_init=kernel_init,
+            bias_init=bias_init,
+            use_bias=use_bias,
+            decode=False,
+        ).train(training)
+
+        flax_key, _ = tx.iter_split(key)  # emulate init split
+        variables = flax_module.init(key, inputs_q, inputs_kv)
+        treex_module = treex_module.init(key, (inputs_q, inputs_kv))
+
+        assert np.allclose(
+            variables["params"]["query"]["kernel"], treex_module.query["kernel"]
+        )
+        assert np.allclose(
+            variables["params"]["key"]["kernel"], treex_module.key["kernel"]
+        )
+        assert np.allclose(
+            variables["params"]["value"]["kernel"], treex_module.value["kernel"]
+        )
+        assert np.allclose(
+            variables["params"]["out"]["kernel"], treex_module.out["kernel"]
+        )
+        if use_bias:
+            assert np.allclose(
+                variables["params"]["query"]["bias"], treex_module.query["bias"]
+            )
+            assert np.allclose(
+                variables["params"]["key"]["bias"], treex_module.key["bias"]
+            )
+            assert np.allclose(
+                variables["params"]["value"]["bias"], treex_module.value["bias"]
+            )
+            assert np.allclose(
+                variables["params"]["out"]["bias"], treex_module.out["bias"]
+            )
+
+        # split key same way tx.Dropout does internally
+        rng, _ = tx.iter_split(flax_key, 2)
+        y_flax = flax_module.apply(
+            variables, rngs={"dropout": rng}, inputs_q=inputs_q, inputs_kv=inputs_kv
+        )
+
+        y_treex = treex_module(inputs_q=inputs_q, inputs_kv=inputs_kv)
+
+        assert np.allclose(y_flax, y_treex)
+
+        assert np.allclose(
+            variables["params"]["query"]["kernel"], treex_module.query["kernel"]
+        )
+        assert np.allclose(
+            variables["params"]["key"]["kernel"], treex_module.key["kernel"]
+        )
+        assert np.allclose(
+            variables["params"]["value"]["kernel"], treex_module.value["kernel"]
+        )
+        assert np.allclose(
+            variables["params"]["out"]["kernel"], treex_module.out["kernel"]
+        )
+        if use_bias:
+            assert np.allclose(
+                variables["params"]["query"]["bias"], treex_module.query["bias"]
+            )
+            assert np.allclose(
+                variables["params"]["key"]["bias"], treex_module.key["bias"]
+            )
+            assert np.allclose(
+                variables["params"]["value"]["bias"], treex_module.value["bias"]
+            )
+            assert np.allclose(
+                variables["params"]["out"]["bias"], treex_module.out["bias"]
+            )
+
+    def test_call(self):
+        key = tx.Key(42)
+        inputs_q = jax.random.uniform(key, shape=(10, 20, 16))
+        inputs_kv = jax.random.uniform(key, shape=(10, 20, 16))
+        inputs = dict(inputs_q=inputs_q, inputs_kv=inputs_kv)
+
+        module = tx.MultiHeadDotProductAttention(num_heads=4).init(key, inputs)
+
+        y = module(**inputs)
+        assert y.shape == (10, 20, 16)
+
+    def test_tree(self):
+        key = tx.Key(42)
+        inputs_q = jax.random.uniform(key, shape=(10, 20, 16))
+        inputs_kv = jax.random.uniform(key, shape=(10, 20, 16))
+        inputs = dict(inputs_q=inputs_q, inputs_kv=inputs_kv)
+
+        module = tx.MultiHeadDotProductAttention(num_heads=4).init(42, inputs)
+
+        flat = jax.tree_leaves(module)
+        assert len(flat) == 9  # q,k,v,o * 2 + rng
+
+    def test_slice(self):
+        key = tx.Key(42)
+        inputs_q = jax.random.uniform(key, shape=(10, 20, 16))
+        inputs_kv = jax.random.uniform(key, shape=(10, 20, 16))
+
+        inputs = dict(inputs_q=inputs_q, inputs_kv=inputs_kv)
+        module = tx.MultiHeadDotProductAttention(num_heads=4).init(42, inputs)
+
+        flat = jax.tree_leaves(module.filter(tx.Parameter))
+
+        assert len(flat) == 8
+
+        flat = jax.tree_leaves(module.filter(tx.State))
+
+        assert len(flat) == 1
+
+    def test_jit(self):
+        key = tx.Key(42)
+        inputs_q = jax.random.uniform(key, shape=(10, 20, 16))
+        inputs_kv = jax.random.uniform(key, shape=(10, 20, 16))
+
+        inputs = dict(inputs_q=inputs_q, inputs_kv=inputs_kv)
+        module = (
+            tx.MultiHeadDotProductAttention(num_heads=4).init(key, inputs).train(False)
+        )
+
+        @jax.jit
+        def f(module, **kwargs):
+            return module, module(**kwargs)
+
+        module2, y = f(module, **inputs)
+
+        assert y.shape == (10, 20, 16)
+        assert all(
+            np.allclose(a, b)
+            for a, b in zip(jax.tree_leaves(module), jax.tree_leaves(module2))
+        )

--- a/treex/nn/__init__.py
+++ b/treex/nn/__init__.py
@@ -1,5 +1,6 @@
 from treex import types
 
+from .attention import MultiHeadDotProductAttention
 from .conv import Conv, ConvTranspose
 from .dropout import Dropout
 from .embed import Embed
@@ -29,6 +30,7 @@ __all__ = [
     "LayerNorm",
     "Linear",
     "MLP",
+    "MultiHeadDotProductAttention",
     "Lambda",
     "Sequential",
     "sequence",

--- a/treex/nn/attention.py
+++ b/treex/nn/attention.py
@@ -1,0 +1,205 @@
+import typing as tp
+
+import jax.numpy as jnp
+from flax.linen import attention as flax_module
+
+from treex import types
+from treex.key_seq import KeySeq
+from treex.module import Module, next_key
+
+PRNGKey = flax_module.PRNGKey
+Shape = flax_module.Shape
+Dtype = flax_module.Dtype
+Array = flax_module.Array
+
+
+class MultiHeadDotProductAttention(Module):
+    """Multi-head dot product attention.
+
+    `MultiHeadDotProductAttention` is implemented as a wrapper over `flax.linen.MultiHeadDotProductAttention`,
+    its constructor arguments accept almost the same arguments including any Flax artifacts such as initializers.
+    """
+
+    # pytree
+    query: tp.Dict[str, jnp.ndarray] = types.Parameter().node()
+    key: tp.Dict[str, jnp.ndarray] = types.Parameter().node()
+    value: tp.Dict[str, jnp.ndarray] = types.Parameter().node()
+    out: tp.Dict[str, jnp.ndarray] = types.Parameter().node()
+
+    # props
+    num_heads: int
+    dtype: Dtype = jnp.float32
+    param_dtype: Dtype = jnp.float32
+    qkv_features: tp.Optional[int] = None
+    out_features: tp.Optional[int] = None
+    broadcast_dropout: bool = True
+    dropout_rate: float = 0.0
+    deterministic: tp.Optional[bool] = None
+    precision: tp.Any = None
+    kernel_init: tp.Callable[
+        [PRNGKey, Shape, Dtype], Array
+    ] = flax_module.default_kernel_init
+    bias_init: tp.Callable[[PRNGKey, Shape, Dtype], Array] = flax_module.zeros
+    use_bias: bool = True
+    attention_fn: tp.Callable[
+        [Array, Array, Array], Array
+    ] = flax_module.dot_product_attention
+    decode: bool = False
+
+    def __init__(
+        self,
+        num_heads: int,
+        dtype: Dtype = jnp.float32,
+        param_dtype: Dtype = jnp.float32,
+        qkv_features: tp.Optional[int] = None,
+        out_features: tp.Optional[int] = None,
+        broadcast_dropout: bool = True,
+        dropout_rate: float = 0.0,
+        deterministic: tp.Optional[bool] = None,
+        precision: tp.Any = None,
+        kernel_init: tp.Callable[
+            [PRNGKey, Shape, Dtype], Array
+        ] = flax_module.default_kernel_init,
+        bias_init: tp.Callable[[PRNGKey, Shape, Dtype], Array] = flax_module.zeros,
+        use_bias: bool = True,
+        attention_fn: tp.Callable[
+            [Array, Array, Array], Array
+        ] = flax_module.dot_product_attention,
+        decode: bool = False,
+        name: tp.Optional[str] = None,
+    ):
+        """
+        Arguments:
+          num_heads: number of attention heads. Features (i.e. inputs_q.shape[-1]) should be divisible by the number of heads.
+          dtype: the dtype of the computation (default: float32)
+          param_dtype: the dtype passed to parameter initializers (default: float32).
+          qkv_features: dimension of the key, query, and value.
+          out_features: dimension of the last projection
+          broadcast_dropout: bool: use a broadcasted dropout along batch dims.
+          dropout_rate: dropout rate
+          deterministic: if false, the attention weight is masked randomly
+            using dropout, whereas if true, the attention weights
+            are deterministic.
+          precision: numerical precision of the computation see `jax.lax.Precision`
+            for details.
+          kernel_init: initializer for the kernel of the Dense layers.
+          bias_init: initializer for the bias of the Dense layers.
+          use_bias: bool: whether pointwise QKVO dense transforms use bias.
+          attention_fn: dot_product_attention or compatible function. Accepts
+            query, key, value, and returns output of shape
+            `[bs, dim1, dim2, ..., dimN,, num_heads, value_channels]``
+          decode: whether to prepare and use an autoregressive cache.
+        """
+        super().__init__(name=name)
+        self.num_heads = num_heads
+        self.dtype = dtype
+        self.param_dtype = param_dtype
+        self.qkv_features = qkv_features
+        self.out_features = out_features
+        self.broadcast_dropout = broadcast_dropout
+        self.dropout_rate = dropout_rate
+        self.deterministic = deterministic
+        self.precision = precision
+        self.kernel_init = kernel_init
+        self.bias_init = bias_init
+        self.use_bias = use_bias
+        self.attention_fn = attention_fn
+        self.decode = decode
+        self.next_key = KeySeq()
+
+    @property
+    def module(self) -> flax_module.MultiHeadDotProductAttention:
+        return flax_module.MultiHeadDotProductAttention(
+            num_heads=self.num_heads,
+            dtype=self.dtype,
+            param_dtype=self.param_dtype,
+            qkv_features=self.qkv_features,
+            out_features=self.out_features,
+            broadcast_dropout=self.broadcast_dropout,
+            dropout_rate=self.dropout_rate,
+            deterministic=self.deterministic,
+            precision=self.precision,
+            kernel_init=self.kernel_init,
+            bias_init=self.bias_init,
+            use_bias=self.use_bias,
+            attention_fn=self.attention_fn,
+            decode=self.decode,
+        )
+
+    def __call__(
+        self,
+        inputs_q: Array,
+        inputs_kv: Array,
+        mask: tp.Optional[Array] = None,
+        deterministic: tp.Optional[bool] = None,
+        rng=None,
+    ):
+        """Applies multi-head dot product attention on the input data.
+
+        Projects the inputs into multi-headed query, key, and value vectors,
+            applies dot-product attention and project the results to an output vector.
+
+        Arguments:
+          inputs_q: input queries of shape
+            `[batch_sizes..., length, features]`.
+          inputs_kv: key/values of shape
+            `[batch_sizes..., length, features]`.
+          mask: attention mask of shape
+            `[batch_sizes..., num_heads, query_length, key/value_length]`.
+            Attention weights are masked out if their corresponding mask value
+            is `False`.
+          deterministic: if false, the attention weight is masked randomly
+            using dropout, whereas if true, the attention weights
+            are deterministic.
+
+        Returns:
+          output of shape `[batch_sizes..., length, features]`.
+        """
+        if self.initializing():
+            rngs = {"params": next_key()}
+            variables = self.module.init(rngs, inputs_q, inputs_kv, mask)
+
+            # Extract collections
+            params = variables["params"].unfreeze()
+
+            self.query = params["query"]
+            self.key = params["key"]
+            self.value = params["value"]
+            self.out = params["out"]
+
+        assert self.query is not None
+        assert self.key is not None
+        assert self.value is not None
+        assert self.out is not None
+
+        if self.use_bias:
+            assert self.query["bias"] is not None
+            assert self.key["bias"] is not None
+            assert self.value["bias"] is not None
+            assert self.out["bias"] is not None
+
+        params = {
+            "query": self.query,
+            "key": self.query,
+            "value": self.value,
+            "out": self.out,
+        }
+
+        training = (
+            not deterministic
+            if deterministic is not None
+            else self.training and not self.frozen
+        )
+
+        if rng is None:
+            rng = self.next_key() if training else self.next_key.key
+
+        output = self.module.apply(
+            {"params": params},
+            inputs_q,
+            inputs_kv,
+            mask,
+            deterministic,
+            rngs={"dropout": rng},
+        )
+        return tp.cast(jnp.ndarray, output)


### PR DESCRIPTION
Adding attention module as a wrapper around `flax.linen.attention`.

I think the wrapper is correct, but I can not get the `test_equivalance` to pass if using Initializer that need rng. I think there's some mismatch between the `next_key()` and my manual emulation of it.

Todo:
- [ ] Fix flax rng split key simulation.
- [ ] Add SelfAttention wrapper.