### PR TITLE
Take any version of cerifi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ rich = "^11.2.0"
 optax = "^0.1.1"
 einops = "^0.4.0"
 treeo = "^0.0.10"
-certifi = "^2021.10.8"
+certifi = ">=2021.10.8"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Certifi has a stable api, only the certificate contents get changed.

So it's safe to assume the the latest is always the version you want.